### PR TITLE
Added read link to determine if the file is a symlink as well.

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -52,7 +52,7 @@ class ScriptHandler {
     }
 
     // Create the files directory with chmod 0777
-    if (!$fs->exists($drupalRoot . '/sites/default/files')) {
+    if (!$fs->exists($drupalRoot . '/sites/default/files') && $fs->readlink($drupalRoot . '/sites/default/files') === null) {
       $oldmask = umask(0);
       $fs->mkdir($drupalRoot . '/sites/default/files', 0777);
       umask($oldmask);


### PR DESCRIPTION
This is a check I am adding per

https://github.com/symfony/symfony/issues/24984

This is not a bug, but rather a specific scenario related to a case on dev servers where we are symlinking directory during the build procoess.
